### PR TITLE
Fix git remote set-url

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,5 +2,5 @@
 
 set -eu
 export GIT_PR_RELEASE_TOKEN=$GITHUB_TOKEN
-git remote set-url origin https://$GITHUB_TOKEN:x-oauth-basic@github.com/$GITHUB_REPOSITORY.git
+git remote set-url origin https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
 git-pr-release


### PR DESCRIPTION
## Probrem

I receive the following error message:

```
remote: Invalid username or password.
fatal: Authentication failed for 'https://github.com/bluerabbit/my_repo.git/'
error: Could not fetch origin
/usr/local/bundle/gems/git-pr-release-0.8.0/bin/git-pr-release:94:in `git': Executing `git remote update origin` failed: pid 14 exit 1 (RuntimeError)
  from /usr/local/bundle/gems/git-pr-release-0.8.0/bin/git-pr-release:300:in `main'
  from /usr/local/bundle/gems/git-pr-release-0.8.0/bin/git-pr-release:412:in `<top (required)>'
  from /usr/local/bundle/bin/git-pr-release:23:in `load'
  from /usr/local/bundle/bin/git-pr-release:23:in `<main>'
##[error]Docker run failed with exit code 1
```

workflows/git-pr-release.yml

```
name: git-pr-release

on:
  push:
    branches:
      - develop

jobs:
  git-pr-release:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v1.2.0
      - name: git-pr-release
        uses: bakunyo/git-pr-release-action@v1.2
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```