### PR TITLE
Support custom arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GitHub Action to run [git-pr-release](https://github.com/motemen/git-pr-release)
 
 For example, here is a workflow to run `git-pr-release` when push to staging.
 
-```
+```yaml
 name: Create PR from staging to master
 on:
   push:
@@ -37,3 +37,15 @@ Add [GITHUB_TOKEN secret](https://help.github.com/en/articles/virtual-environmen
 #### Other optional environment variables
 
 Any environment variables defined by [git-pr-release](https://github.com/motemen/git-pr-release) also can use on this action (`GIT_PR_RELEASE_BRANCH_PRODUCTION`, `GIT_PR_RELEASE_BRANCH_STAGING` etc).
+
+### Custom arguments
+`git-pr-release` command supports some arguments. These can be specified by using `args` input.
+
+```yaml
+- name: git-pr-release
+  uses: bakunyo/git-pr-release-action@master
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    args: '--squashed' # If you are using squash merge
+```

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,16 @@
 name: "git-pr-release"
 description: "Run git-pr-release"
 author: "bakunyo <izuta.hiroyuki@gmail.com>"
+inputs:
+  args:
+    description: "Specify the arguments to the git-pr-release command"
+    required: false
+    default: ''
 runs:
   using: "docker"
   image: "Dockerfile"
+  args:
+    - ${{ inputs.args }}
 branding:
   icon: "check-square"
   color: "green"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 
 set -eu
 export GIT_PR_RELEASE_TOKEN=$GITHUB_TOKEN
-git-pr-release
+git-pr-release $1


### PR DESCRIPTION
Hi,

`git-pr-release` supports arguments such as `--squashed` (PR: https://github.com/x-motemen/git-pr-release/pull/60) .
In this PR, the arguments are made available in GitHub Actions.

ref. https://github.com/bakunyo/git-pr-release-action/issues/13