### PR TITLE
Add pwd to git's `safe.directory`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,5 @@
 
 set -eu
 export GIT_PR_RELEASE_TOKEN=$GITHUB_TOKEN
+git config --global --add safe.directory $(pwd)
 git-pr-release


### PR DESCRIPTION
Close #15 

This workaround is quick fix for now, but this issue might be fixed by GitHub Actions runner.