### PR TITLE
Upgrade Ruby to 3.4 (alpine3.22)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ruby:3.0.0-alpine3.13
+FROM ruby:3.4-alpine3.22
 
 RUN apk --update --no-cache upgrade && \
     apk --no-cache add git tzdata && \
     gem install --no-document git-pr-release
 
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary

- Upgraded Ruby base image from 3.0.0 to 3.4 (alpine3.22)
- Changed `ADD` to `COPY` for better clarity

## Rationale

### Ruby version upgrade
The previous Ruby version (3.0.0) is no longer supported on Docker Hub. This PR updates to Ruby 3.4 with Alpine 3.22, which is currently supported and maintained.

### ADD to COPY change
Also replaced `ADD` with `COPY` when copying `entrypoint.sh` to make the intent clearer. `COPY` is more explicit for simple file copying operations.